### PR TITLE
#34 - Processing of recipe images on backend

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -69,6 +69,11 @@
 			<artifactId>springdoc-openapi-ui</artifactId>
 			<version>1.6.6</version>
 		</dependency>
+		<dependency>
+			<groupId>net.coobird</groupId>
+			<artifactId>thumbnailator</artifactId>
+			<version>0.4.17</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/backend/src/main/java/no/hvl/dat251/recipeapp/controller/RecipeController.java
+++ b/backend/src/main/java/no/hvl/dat251/recipeapp/controller/RecipeController.java
@@ -10,6 +10,7 @@ import no.hvl.dat251.recipeapp.domain.Recipe;
 import no.hvl.dat251.recipeapp.service.RecipeService;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
@@ -69,6 +70,14 @@ public class RecipeController {
     })
     public ResponseEntity<Recipe> getRecipe(@PathVariable Integer id) {
         return ResponseEntity.ok(recipeService.getRecipe(id));
+    }
+
+    @GetMapping(value = "/recipe-image/{id}.jpg", produces = MediaType.IMAGE_JPEG_VALUE)
+    @Operation(summary = "Get recipe image by ID", responses = {
+            @ApiResponse(responseCode = "200", description = "Successful operation")
+    })
+    public ResponseEntity<byte[]> getRecipeImage(@PathVariable Integer id) {
+        return ResponseEntity.ok(recipeService.getRecipeImage(id));
     }
 
     @PostMapping("/recipe")

--- a/backend/src/main/java/no/hvl/dat251/recipeapp/domain/Recipe.java
+++ b/backend/src/main/java/no/hvl/dat251/recipeapp/domain/Recipe.java
@@ -44,6 +44,10 @@ public class Recipe implements ObjectWithId {
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private Instant created;
 
+    @Lob
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    private byte[] image;
+
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private transient double averageRating;
 

--- a/backend/src/main/java/no/hvl/dat251/recipeapp/security/SecurityConfig.java
+++ b/backend/src/main/java/no/hvl/dat251/recipeapp/security/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         Map<HttpMethod, Set<String>> excludedEndpoints = new HashMap<>();
-        excludedEndpoints.put(HttpMethod.GET, new HashSet<>(Arrays.asList("/api-documentation/**", "/v3/api-docs/**", "/swagger-ui/**")));
+        excludedEndpoints.put(HttpMethod.GET, new HashSet<>(Arrays.asList("/api-documentation/**", "/v3/api-docs/**", "/swagger-ui/**", "/recipe-image/**")));
         excludedEndpoints.put(HttpMethod.POST, new HashSet<>(Arrays.asList("/login", "/user")));
 
         http.csrf().disable();


### PR DESCRIPTION
Images are prepared on backend. Just send them in base64 format with recipe (I added examples to postman or see generated documentation for endpoints). Images can be in any format and size, backend will automatically resize them to max. 800x600px and convert to jpeg. Image will be available at `/recipe-image/{id}.jpg` endpoint after creating of recipe so you can just link image source in html.

closes #34 